### PR TITLE
Adds first/last name to example user attributes

### DIFF
--- a/config/simplesamlphp/authsources.php
+++ b/config/simplesamlphp/authsources.php
@@ -1,7 +1,6 @@
 <?php
 
 $config = array(
-
     'admin' => array(
         'core:AdminPassword',
     ),
@@ -10,14 +9,26 @@ $config = array(
         'exampleauth:UserPass',
         'user1:user1pass' => array(
             'uid' => array('1'),
-            'eduPersonAffiliation' => array('group1'),
-            'email' => 'user1@example.com',
+            'first_name' => 'User',
+            'last_name' => 'One',
+            'email' => 'user_1@example.com',
         ),
         'user2:user2pass' => array(
             'uid' => array('2'),
-            'eduPersonAffiliation' => array('group2'),
-            'email' => 'user2@example.com',
+            'first_name' => 'User',
+            'last_name' => 'Two',
+            'email' => 'user_2@example.com',
+        ),
+        'user3:user3pass' => array(
+            'uid' => array('3'),
+            'first_name' => 'User',
+            'last_name' => 'Three',
+            'email' => 'user_3@example.com',
+        ),
+        'user4:user4pass' => array(
+            'uid' => array('4'),
+            'name' => 'User Four',
+            'email' => 'user_4@example.com',
         ),
     ),
-
 );


### PR DESCRIPTION
Also adds two additional example users as well as removing the
eduPersonAffiliation example attribute.

These changes are to align with GitLab, where some form of name
is required when automatically creating accounts.